### PR TITLE
Specify requirements in separate files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           python-version: '3.10'
           cache: pip
+          cache-dependency-path: '**/requirements-dev.txt'
       - name: Install pip
         run: |
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-requirements-txt"]
 build-backend = "hatchling.build"
 
 [project]
@@ -15,13 +15,7 @@ classifiers = [
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "Operating System :: OS Independent",
 ]
-dynamic = ["version"]
-
-[project.optional-dependencies]
-dev = [
-    "black",
-    "pytest",
-]
+dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [project.urls]
 "Homepage" = "https://github.com/jakobj/git-foss-workflow-lecture"
@@ -29,3 +23,9 @@ dev = [
 
 [tool.hatch.version]
 path = "meaningful/__init__.py"
+
+[tool.hatch.metadata.hooks.requirements_txt]
+files = ["requirements.txt"]
+
+[tool.hatch.metadata.hooks.requirements_txt.optional-dependencies]
+dev = ["requirements-dev.txt"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+black
+pytest


### PR DESCRIPTION
Previously, these were specified only in `pyproject.toml`. Putting them in separate files is cleaner and (hopefully) allows for efficient GitHub actions caching.